### PR TITLE
feat: Add ErrorResponse class and unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@easygrating/easyrouting",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@easygrating/easyrouting",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@easygrating/nmodules-loader": "^1.1.1",
+        "http-status-codes": "^2.3.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -2491,6 +2492,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/human-signals": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@easygrating/nmodules-loader": "^1.1.1",
+    "http-status-codes": "^2.3.0",
     "lodash": "^4.17.21"
   }
 }

--- a/src/core/enums/index.ts
+++ b/src/core/enums/index.ts
@@ -5,3 +5,15 @@ export enum RouterInitEvents {
   BEFORE_INIT = "BEFORE_INIT",
   AFTER_INIT = "AFTER_INIT",
 }
+
+/**
+ * HTTP Response type names
+ */
+export enum ResponseTypes {
+  BASIC = "basic",
+  CORS = "cors",
+  DEFAULT = "default",
+  ERROR = "error",
+  OPAQUE = "opaque",
+  OPAQUEREDIRECT = "opaqueredirect",
+}

--- a/src/core/models/error-response.ts
+++ b/src/core/models/error-response.ts
@@ -1,0 +1,40 @@
+import { StatusCodes } from "http-status-codes";
+
+/**
+ * ErrorResponse class for handling error responses.
+ * @usage
+```
+let errorResponse = ErrorResponse.badRequest('Invalid input', ['Name is required']);
+```
+ */
+export class ErrorResponse {
+  responseType: string;
+  statusCode: number;
+  message: string;
+  errors: string[];
+
+  /**
+   * ErrorResponse constructor.
+   * @param {number} statusCode - The HTTP status code of the error.
+   * @param {string} message - The error message.
+   * @param {string[]} errors - The array of validation errors.
+   */
+  constructor(statusCode: number, message: string, errors: string[]) {
+    this.responseType = "error";
+    this.statusCode = statusCode;
+    this.message = message;
+    this.errors = errors;
+  }
+
+  /**
+   * Factory method for creating a bad request error response.
+   * @param {string} message - The error message.
+   * @param {string[]} errors - The array of validation errors.
+   * @returns {ErrorResponse} A new ErrorResponse instance.
+   */
+  static badRequest(message: string, errors: string[]) {
+    return new ErrorResponse(StatusCodes.BAD_REQUEST, message, errors);
+  }
+
+  // TODO: more static methods for other status codes can be added as needed or through inheritance.
+}

--- a/src/core/models/error-response.ts
+++ b/src/core/models/error-response.ts
@@ -12,7 +12,7 @@ export class ErrorResponse {
   responseType: ResponseTypes;
   statusCode: StatusCodes;
   message: string;
-  errors: string[];
+  errors?: string[];
 
   /**
    * ErrorResponse constructor.
@@ -20,7 +20,7 @@ export class ErrorResponse {
    * @param {string} message - The error message.
    * @param {string[]} errors - The array of validation errors.
    */
-  constructor(statusCode: StatusCodes, message: string, errors: string[]) {
+  constructor(statusCode: StatusCodes, message: string, errors?: string[]) {
     this.responseType = ResponseTypes.ERROR;
     this.statusCode = statusCode;
     this.message = message;
@@ -34,8 +34,18 @@ export class ErrorResponse {
    * @param {string[]} errors - The array of validation errors.
    * @returns {ErrorResponse} A new ErrorResponse instance.
    */
-  static createError(statusCode: StatusCodes, errors: string[]): ErrorResponse {
+  static createError(statusCode: StatusCodes, errors?: string[]): ErrorResponse {
     const message = getReasonPhrase(statusCode);
     return new ErrorResponse(statusCode, message, errors);
+  }
+
+  /**
+   * Factory method for creating a bad request error response.
+   * @param {string} message - The error message.
+   * @param {string[]} errors - The array of validation errors.
+   * @returns {ErrorResponse} A new ErrorResponse instance.
+   */
+  static badRequest(message: string, errors: string[]): ErrorResponse {
+    return new ErrorResponse(StatusCodes.BAD_REQUEST, message, errors);
   }
 }

--- a/src/core/models/error-response.ts
+++ b/src/core/models/error-response.ts
@@ -1,15 +1,16 @@
-import { StatusCodes } from "http-status-codes";
+import { StatusCodes, getReasonPhrase } from "http-status-codes";
+import { ResponseTypes } from "../enums";
 
 /**
  * ErrorResponse class for handling error responses.
  * @usage
 ```
-let errorResponse = ErrorResponse.badRequest('Invalid input', ['Name is required']);
+let errorResponse = ErrorResponse.createError(StatusCodes.INTERNAL_SERVER_ERROR, ['Name is required']);
 ```
  */
 export class ErrorResponse {
-  responseType: string;
-  statusCode: number;
+  responseType: ResponseTypes;
+  statusCode: StatusCodes;
   message: string;
   errors: string[];
 
@@ -19,22 +20,22 @@ export class ErrorResponse {
    * @param {string} message - The error message.
    * @param {string[]} errors - The array of validation errors.
    */
-  constructor(statusCode: number, message: string, errors: string[]) {
-    this.responseType = "error";
+  constructor(statusCode: StatusCodes, message: string, errors: string[]) {
+    this.responseType = ResponseTypes.ERROR;
     this.statusCode = statusCode;
     this.message = message;
     this.errors = errors;
   }
 
   /**
-   * Factory method for creating a bad request error response.
+   * Factory method for creating a request error response.
+   * @param {StatusCodes} statusCode - The error status code.
    * @param {string} message - The error message.
    * @param {string[]} errors - The array of validation errors.
    * @returns {ErrorResponse} A new ErrorResponse instance.
    */
-  static badRequest(message: string, errors: string[]) {
-    return new ErrorResponse(StatusCodes.BAD_REQUEST, message, errors);
+  static createError(statusCode: StatusCodes, errors: string[]): ErrorResponse {
+    const message = getReasonPhrase(statusCode);
+    return new ErrorResponse(statusCode, message, errors);
   }
-
-  // TODO: more static methods for other status codes can be added as needed or through inheritance.
 }

--- a/test/core/models/error-response.spec.ts
+++ b/test/core/models/error-response.spec.ts
@@ -32,4 +32,15 @@ describe("ErrorResponse", () => {
     );
     expect(errorResponse.errors).toEqual(errors);
   });
+
+  it('should create a bad request error response with custom message', () => {
+    const errors = ['Name is required'];
+    const message = 'Validation error';
+    const errorResponse = ErrorResponse.badRequest(message, errors);
+
+    expect(errorResponse.responseType).toBe('error');
+    expect(errorResponse.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(errorResponse.message).toBe(message);
+    expect(errorResponse.errors).toEqual(errors);
+});
 });

--- a/test/core/models/error-response.spec.ts
+++ b/test/core/models/error-response.spec.ts
@@ -1,0 +1,15 @@
+import { StatusCodes } from 'http-status-codes';
+import { ErrorResponse } from '../../../src/core/models/error-response';
+
+describe('ErrorResponse', () => {
+    it('should create an error response with the correct properties', () => {
+        const errors = ['Name is required'];
+        const message = 'Invalid input';
+        const errorResponse = ErrorResponse.badRequest(message, errors);
+
+        expect(errorResponse.responseType).toBe('error');
+        expect(errorResponse.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(errorResponse.message).toBe(message);
+        expect(errorResponse.errors).toEqual(errors);
+    });
+});

--- a/test/core/models/error-response.spec.ts
+++ b/test/core/models/error-response.spec.ts
@@ -1,15 +1,35 @@
-import { StatusCodes } from 'http-status-codes';
-import { ErrorResponse } from '../../../src/core/models/error-response';
+import { StatusCodes, getReasonPhrase } from "http-status-codes";
+import { ErrorResponse } from "../../../src/core/models/error-response";
 
-describe('ErrorResponse', () => {
-    it('should create an error response with the correct properties', () => {
-        const errors = ['Name is required'];
-        const message = 'Invalid input';
-        const errorResponse = ErrorResponse.badRequest(message, errors);
+describe("ErrorResponse", () => {
+  it("should correctly set properties in constructor", () => {
+    const errors = ["Error 1", "Error 2"];
+    const errorResponse = new ErrorResponse(
+      StatusCodes.BAD_REQUEST,
+      getReasonPhrase(StatusCodes.BAD_REQUEST),
+      errors
+    );
 
-        expect(errorResponse.responseType).toBe('error');
-        expect(errorResponse.statusCode).toBe(StatusCodes.BAD_REQUEST);
-        expect(errorResponse.message).toBe(message);
-        expect(errorResponse.errors).toEqual(errors);
-    });
+    expect(errorResponse.responseType).toEqual("error");
+    expect(errorResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    expect(errorResponse.message).toEqual(
+      getReasonPhrase(StatusCodes.BAD_REQUEST)
+    );
+    expect(errorResponse.errors).toEqual(errors);
+  });
+
+  it("should create error response with factory method", () => {
+    const errors = ["Error 1", "Error 2"];
+    const errorResponse = ErrorResponse.createError(
+      StatusCodes.BAD_REQUEST,
+      errors
+    );
+
+    expect(errorResponse.responseType).toEqual("error");
+    expect(errorResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    expect(errorResponse.message).toEqual(
+      getReasonPhrase(StatusCodes.BAD_REQUEST)
+    );
+    expect(errorResponse.errors).toEqual(errors);
+  });
 });


### PR DESCRIPTION
This commit introduces the _ErrorResponse_ class for handling error responses. The class includes a _responseType_, _statusCode_, _message_, and _errors_ property. The _errors_ property is an array that can be used for validation errors.

In addition, this commit includes Jest unit tests for the _ErrorResponse_ class. The tests ensure that the properties of the error response are set correctly when using the _badRequest_ method.

- Fix #2